### PR TITLE
Fix the callable typehint

### DIFF
--- a/knpu/scalar-type-hints.md
+++ b/knpu/scalar-type-hints.md
@@ -18,7 +18,7 @@ Cool! In the browser, head to `/types` to check it out. It works! Even though *w
 think `name` should be a string, PHP lets us pass whatever we want. Right now,
 `name` is actually an int.
 
-In PHP 5, we *could* type-hint arguments... but only with either `array`, `closure`
+In PHP 5, we *could* type-hint arguments... but only with either `array`, `callable`
 or a class name. Well, no more! In PHP 7, we can type-hint with `string`... or `int`,
 `float`, `bool` or `pizza`. Wait, not `pizza`.
 


### PR DESCRIPTION
the callable typehint in PHP 5.x is `callable`, not `closure` (you can typehint `\Closure`, but this is a class name. And typehinting `closure` without the `\` is equivalent only when being in the global namespace)