### PR TITLE
Fix the name for the new iterable type

### DIFF
--- a/knpu/return-types.md
+++ b/knpu/return-types.md
@@ -18,7 +18,7 @@ that should return a string, but is instead returning an integer. Lame!
 
 To fix this, add a return type. After the method name, add `: string`. Of course,
 this could be *any* type: a class name, `int`, `bool`, `float`, `array`, `callable`
-or even the new `traversable`. More on that later.
+or even the new `iterable`. More on that later.
 
 As *soon* as we do this, PhpStorm is furious all over again! And so is PHP: refresh!
 


### PR DESCRIPTION
`Traversable` is not new, and it is an interface name, not a pseudo-type, which means that using it as a return type obeys the rules of class names (you need to qualify it as `\Traversable` or import it)